### PR TITLE
Enable variables in git path

### DIFF
--- a/match/lib/match/git_helper.rb
+++ b/match/lib/match/git_helper.rb
@@ -25,7 +25,7 @@ module Match
 
       @dir = Dir.mktmpdir
 
-      command = "git clone '#{git_url}' '#{@dir}'"
+      command = %(git clone "#{git_url}" '#{@dir}')
       if shallow_clone
         command << " --depth 1 --no-single-branch"
       elsif clone_branch_directly

--- a/match/spec/git_helper_spec.rb
+++ b/match/spec/git_helper_spec.rb
@@ -18,7 +18,7 @@ describe Match do
         expect(Dir).to receive(:mktmpdir).and_return(path)
         git_url = "https://github.com/fastlane/fastlane/tree/master/certificates"
         shallow_clone = false
-        command = "GIT_TERMINAL_PROMPT=0 git clone '#{git_url}' '#{path}'"
+        command = "GIT_TERMINAL_PROMPT=0 git clone \"#{git_url}\" '#{path}'"
         to_params = {
           command: command,
           print_all: nil,
@@ -40,7 +40,7 @@ describe Match do
         expect(Dir).to receive(:mktmpdir).and_return(path)
         git_url = "https://github.com/fastlane/fastlane/tree/master/certificates"
         shallow_clone = true
-        command = "GIT_TERMINAL_PROMPT=0 git clone '#{git_url}' '#{path}' --depth 1 --no-single-branch"
+        command = "GIT_TERMINAL_PROMPT=0 git clone \"#{git_url}\" '#{path}' --depth 1 --no-single-branch"
         to_params = {
           command: command,
           print_all: nil,
@@ -62,7 +62,7 @@ describe Match do
         expect(Dir).to receive(:mktmpdir).and_return(path)
         git_url = "https://github.com/fastlane/fastlane/tree/master/certificates"
         shallow_clone = false
-        command = "GIT_TERMINAL_PROMPT=0 git clone '#{git_url}' '#{path}'"
+        command = "GIT_TERMINAL_PROMPT=0 git clone \"#{git_url}\" '#{path}'"
         to_params = {
           command: command,
           print_all: nil,
@@ -85,7 +85,7 @@ describe Match do
         git_url = "https://github.com/fastlane/fastlane/tree/master/certificates"
         git_branch = "test"
         shallow_clone = false
-        command = "GIT_TERMINAL_PROMPT=0 git clone '#{git_url}' '#{path}'"
+        command = "GIT_TERMINAL_PROMPT=0 git clone \"#{git_url}\" '#{path}'"
         to_params = {
           command: command,
           print_all: nil,


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This change allows using environment variables in git paths (this is very useful or even mandatory to use a repository with certificates on GitLab).

### Description
Change is quite simple - I just replaced single quotes with double ones.
